### PR TITLE
Add license to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "maths22/sexp-php",
     "description": "S-expression parser for PHP",
+    "license": "MIT",
     "require": {
         "php": ">=5.3.0"
     },


### PR DESCRIPTION
Not very important, but `composer licenses` gave me "None" as license and I thought I should fix it.